### PR TITLE
Se elimina la sesion si el estado de isAuthenticated cambia

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
+import { auth } from "@/auth";
 import { fontTitle } from "@/src/config/fonts";
+import { logoutUser } from "@/src/lib/actions/auth";
 import type { ILayout } from "@/src/types/components";
 
 import "@/src/styles/globals.css";
@@ -9,7 +11,18 @@ export const metadata: Metadata = {
     description: "Tienda Virtual de TRD Caribe",
 };
 
-export default function RootLayout({ children }: ILayout) {
+export default async function RootLayout({ children }: ILayout) {
+    // Se recupera la sesión del usuario
+    const session = await auth();
+
+    // Se comprueba la sesión del usuario
+    // Debido q que si el servidor se apaga, la sesión de auth js se matiene viva
+    // Por lo que se debe cerrar la sesión
+    if (session && session?.isAuthenticated === false) {
+        // Si el usuario no está autenticado, se cierra la sesión
+        await logoutUser();   
+    }
+
     return (
         <html lang="es">
             <body className={`${fontTitle.className} antialiased`}>


### PR DESCRIPTION
Se comprueba el estado de la sesion al cargar la página, porque cuando se cae el servidor de Render se eliminan los tokens, pero la sesion de Auth js no se cerraba correctamente.